### PR TITLE
fix/ping appimagetool version

### DIFF
--- a/docker/package.Dockerfile
+++ b/docker/package.Dockerfile
@@ -7,10 +7,7 @@ RUN apt -y update && apt -y upgrade
 ## Install system dependencies
 RUN apt -y install binutils desktop-file-utils dpkg file imagemagick wget xz-utils pv curl jq python3
 
-# FIXME: it would be better if we could find some way to
-# pin this to a fixed version, instead of blindly downloading
-# some random backdoorable binary.
-RUN curl -s https://api.github.com/repos/AppImage/appimagetool/releases/latest \
+RUN curl -s https://api.github.com/repos/AppImage/appimagetool/releases/tags/1.9.0 \
     | jq -r '.assets[].browser_download_url' \
     | grep $(uname -m) \
     | xargs curl -Lo /usr/bin/appimagetool


### PR DESCRIPTION
Targeting the latest release - https://github.com/AppImage/appimagetool/releases/tag/1.9.0

Doc for endpoint used - https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-a-release-by-tag-name

Assuming AppImage don't change the tag name this should work fine.