### PR TITLE
Revert "flags: build without gtk and qt[56]"

### DIFF
--- a/flags.linux.gn
+++ b/flags.linux.gn
@@ -13,6 +13,3 @@ use_kerberos=false
 use_sysroot=true
 use_vaapi=true
 use_system_libffi=false
-use_gtk=false
-use_qt5=false
-use_qt6=false


### PR DESCRIPTION
This reverts commit 33da31c0096d6c46be7fc546def6799e853f538a.