### PR TITLE
package: specify StartupWMClass value

### DIFF
--- a/package/helium.desktop
+++ b/package/helium.desktop
@@ -5,6 +5,7 @@ GenericName=Web Browser
 Comment=Access the Internet
 Exec=chromium %U
 StartupNotify=true
+StartupWMClass=helium
 Terminal=false
 Icon=helium
 Type=Application


### PR DESCRIPTION
Should fix the missing icon and "user friendly" app title for Helium on the taskbar/dock. Before:

<img width="872" height="199" alt="image" src="https://github.com/user-attachments/assets/725f4381-5fd1-40cf-b750-b3535fa8e95a" />

After:

<img width="821" height="197" alt="image" src="https://github.com/user-attachments/assets/26d42215-4fc0-471d-8ebc-5393d08b6f39" />