### PR TITLE
helium/linux: enable TouchpadOverscrollHistoryNavigation by default

### DIFF
--- a/patches/helium/linux/fix-swipe-between-pages.patch
+++ b/patches/helium/linux/fix-swipe-between-pages.patch
@@ -1,0 +1,11 @@
+--- a/content/common/features.cc
++++ b/content/common/features.cc
+@@ -690,7 +690,7 @@ const base::FeatureParam<base::TimeDelta
+ // only enabled by default on CrOS and Windows.
+ BASE_FEATURE(kTouchpadOverscrollHistoryNavigation,
+              "TouchpadOverscrollHistoryNavigation",
+-#if BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_WIN)
++#if BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX)
+              base::FEATURE_ENABLED_BY_DEFAULT
+ #else
+              base::FEATURE_DISABLED_BY_DEFAULT

--- a/patches/series
+++ b/patches/series
@@ -5,3 +5,4 @@ ungoogled-chromium/portablelinux/fix-compiling-on-arm64.patch
 helium/linux/change-chromium-branding.patch
 helium/linux/use-default-theme.patch
 helium/linux/upstream-fix-wayland-color-management.patch
+helium/linux/fix-swipe-between-pages.patch


### PR DESCRIPTION
fixes #57