### PR TITLE
[packaging] Remove sed for exec as it breaks links not opening if installed with appimage package managers & add %U

### DIFF
--- a/package/helium.desktop
+++ b/package/helium.desktop
@@ -173,7 +173,7 @@ Name[uk]=Нове вікно
 Name[vi]=Cửa sổ Mới
 Name[zh_CN]=新建窗口
 Name[zh_TW]=開新視窗
-Exec=helium %U
+Exec=helium
 
 [Desktop Action new-private-window]
 Name=New Incognito Window


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [x] An issue exists where the maintainers agreed that this should be implemented.
      If such issue did not exist before, I opened one.
- [x] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [x] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.
- [x] The pull request contents are only relevant to the Linux platform, and can in
      no way be applied to other platforms.
---

[short description of your PR goes here]
As of right now if a user install helium with a package manager like soar or am the Exec on the .desktop file will be changed with the path to the executable and this messes up %U, making links not open properly. This pr fixes that.

Left: .desktop from --appimage-extract
Right: .desktop from helium installed via packages.toml which has; `helium = { github = "imputnet/helium-linux", asset_pattern = "*x86_64.AppImage", version = "*" }`

<img width="1907" height="1069" alt="image" src="https://github.com/user-attachments/assets/4f671f81-048d-4518-a260-23515a9da3bf" />