### PR TITLE
helium/ui: don't draw tab strokes

### DIFF
--- a/patches/helium/linux/disable-tab-strokes.patch
+++ b/patches/helium/linux/disable-tab-strokes.patch
@@ -1,0 +1,14 @@
+--- a/chrome/browser/ui/views/frame/browser_view.cc
++++ b/chrome/browser/ui/views/frame/browser_view.cc
+@@ -1424,9 +1424,9 @@ bool BrowserView::GetTabStripVisible() c
+ }
+ 
+ bool BrowserView::ShouldDrawTabStrokes() const {
+-#if BUILDFLAG(IS_CHROMEOS)
++#if BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_LINUX)
+   return false;
+-#else   // BUILDFLAG(IS_CHROMEOS)
++#else   // BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_LINUX)
+ 
+   if (browser()->app_controller() &&
+       !browser()->app_controller()->has_tab_strip()) {

--- a/patches/series
+++ b/patches/series
@@ -8,3 +8,4 @@ helium/linux/use-default-theme.patch
 helium/linux/fix-swipe-between-pages.patch
 helium/linux/add-middle-click-paste-flag.patch
 helium/linux/add-error-for-missing-desktop-file.patch
+helium/linux/disable-tab-strokes.patch


### PR DESCRIPTION
before:
<img width="1140" height="134" alt="Screenshot 2026-04-06 at 14 53 52" src="https://github.com/user-attachments/assets/d22e9113-8460-4c4d-99c1-946311622204" />

<img width="1145" height="142" alt="Screenshot 2026-04-06 at 14 53 58" src="https://github.com/user-attachments/assets/281b3551-670a-4c0a-b226-e6d3592a1fb7" />

after:
<img width="1171" height="157" alt="Screenshot 2026-04-06 at 14 54 58" src="https://github.com/user-attachments/assets/efae77f4-839c-471c-b560-a6f1a4f81b39" />
<img width="1189" height="167" alt="Screenshot 2026-04-06 at 14 55 01" src="https://github.com/user-attachments/assets/d5b02190-ac6d-4eee-a5e4-c0b361fa0b30" />
