### PR TITLE
build: enable symbols, generate artifact with symbols

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -61,6 +61,14 @@ runs:
         if-no-files-found: error
         compression-level: 0
 
+    - name: Upload symbols artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: helium-${{ steps.version.outputs.version }}-${{ env.ARCH }}-symbols
+        path: build/release/helium-${{ steps.version.outputs.version }}-${{ env.ARCH }}_symbols.zip
+        if-no-files-found: error
+        compression-level: 0
+
     - name: Upload .deb artifact
       uses: actions/upload-artifact@v4
       with:

--- a/docker/package.Dockerfile
+++ b/docker/package.Dockerfile
@@ -8,7 +8,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 RUN apt -y update && apt -y upgrade
 
 ## Install system dependencies
-RUN apt -y install binutils elfutils desktop-file-utils dpkg dpkg-dev fakeroot file git imagemagick wget xz-utils pv curl jq python3 zsync gnupg perl make liblocale-gettext-perl
+RUN apt -y install binutils elfutils desktop-file-utils dpkg dpkg-dev fakeroot file git imagemagick wget xz-utils pv curl jq python3 zip zsync gnupg perl make liblocale-gettext-perl
 
 ## Install Chromium runtime libraries for debbuild resolution
 RUN apt -y install --no-install-recommends \

--- a/flags.linux.gn
+++ b/flags.linux.gn
@@ -1,5 +1,5 @@
 is_official_build=true
-symbol_level=0
+symbol_level=1
 disable_fieldtrial_testing_config=true
 blink_enable_generated_code_formatting=false
 blink_symbol_level=0

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -64,6 +64,13 @@ cp "$_root_dir/package/helium-wrapper.sh" "$_tarball_dir/helium-wrapper"
 wait
 (cd "$_tarball_dir" && ln -sf helium chrome)
 
+_syms_zip="$_release_dir/${_release_name}_symbols.zip"
+rm -f "$_syms_zip"
+find "$_tarball_dir" -type f -exec file {} + \
+    | awk -F: '/ELF/ {print $1}' \
+    | sed "s|^$_tarball_dir/||" \
+    | (cd "$_build_dir/src/out/Default" && zip -q "$_syms_zip" -@)
+
 if command -v eu-strip >/dev/null 2>&1; then
     _strip_cmd=eu-strip
 else


### PR DESCRIPTION
this will lead to a +35.5 mb (13%) binary and roughly +9 mb (7%) compressed package size increase, but i think it's worth it to be able to actually debug and diagnose crashes