### PR TITLE
dev.sh: call proper (un)merge function in he pull

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -129,7 +129,7 @@ ___helium_pull() {
     fi
 
     cd "$_src_dir" && quilt pop -a || true
-    "$_root_dir/devutils/update_patches.sh" unmerge || true
+    ___helium_patches_op unmerge || true
 
     for dir in "$_root_dir" "$_main_repo"; do
         git -C "$dir" stash \
@@ -139,7 +139,7 @@ ___helium_pull() {
         || true
     done
 
-    "$_root_dir/devutils/update_patches.sh" merge
+    ___helium_patches_op merge
     cd "$_src_dir" && quilt push -a --refresh
 }
 


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [x] An issue exists where the maintainers agreed that this should be implemented.
      If such issue did not exist before, I opened one.
- [x] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [x] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.
- [x] The pull request contents are only relevant to the Linux platform, and can in
      no way be applied to other platforms.
---

This was a leftover from the macos porting PR (#19). It referenced a non-existing `devutils/update_patches.sh` script that only exists on the macos repo for platform for compatibility.

We have the `___helium_patches_op` function on the linux build script that provides the same functionality and is used where the macos version calls its compatibility script.